### PR TITLE
Add dumb-init to get rid of stalled chrome copies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -qqy \
   && apt-get -qqy install \
-       wget curl \
+       dumb-init wget curl \
        ca-certificates apt-transport-https \
        ttf-wqy-zenhei \
        fonts-thai-tlwg-ttf \
@@ -105,6 +105,6 @@ USER headless
 # https://github.com/SeleniumHQ/docker-selenium/issues/87
 ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
 
-ENTRYPOINT ["java", "-jar", "/opt/selenium/selenium-server-standalone.jar"]
+ENTRYPOINT ["/usr/bin/dumb-init","--","java","-jar","/opt/selenium/selenium-server-standalone.jar"]
 
 EXPOSE 4444


### PR DESCRIPTION
Current image has a problem with a stalled copies:
```
headless@af00e7fb068c:/$ ps aux
USER        PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
headless      1  0.8  0.7 5017272 64404 ?       Ssl  10:07   0:00 java -jar /opt/selenium/selenium-server-standalone.jar
headless     35  0.0  0.0  18208  3360 pts/0    Ss   10:07   0:00 bash
headless    412  0.0  0.0  36632  2856 pts/0    R+   10:08   0:00 ps aux

$ run tests

headless@af00e7fb068c:/$ ps aux
USER        PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
headless      1  3.8  1.5 5629080 126144 ?      Ssl  10:07   0:03 java -jar /opt/selenium/selenium-server-standalone.jar
headless    438  0.0  0.0      0     0 ?        Z    10:08   0:00 [cat] <defunct>
headless    439  0.0  0.0      0     0 ?        Z    10:08   0:00 [cat] <defunct>
headless    441  0.0  0.0      0     0 ?        Z    10:08   0:00 [chrome] <defunct>
headless    477 28.6  0.0      0     0 ?        Z    10:08   0:04 [chrome] <defunct>
headless    498  1.0  0.0  18208  3280 pts/0    Ss   10:08   0:00 bash
headless    505  0.0  0.0  36632  2864 pts/0    R+   10:08   0:00 ps aux

$ run tests

headless@af00e7fb068c:/$ ps aux
USER        PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
headless      1  4.7  1.6 5631136 131996 ?      Ssl  10:07   0:05 java -jar /opt/selenium/selenium-server-standalone.jar
headless    438  0.0  0.0      0     0 ?        Z    10:08   0:00 [cat] <defunct>
headless    439  0.0  0.0      0     0 ?        Z    10:08   0:00 [cat] <defunct>
headless    441  0.0  0.0      0     0 ?        Z    10:08   0:00 [chrome] <defunct>
headless    477 13.5  0.0      0     0 ?        Z    10:08   0:04 [chrome] <defunct>
headless    526  0.0  0.0      0     0 ?        Z    10:09   0:00 [cat] <defunct>
headless    527  0.0  0.0      0     0 ?        Z    10:09   0:00 [cat] <defunct>
headless    529  0.1  0.0      0     0 ?        Z    10:09   0:00 [chrome] <defunct>
headless    566 34.8  0.0      0     0 ?        Z    10:09   0:04 [chrome] <defunct>
headless    584  0.3  0.0  18208  3392 pts/0    Ss   10:09   0:00 bash
headless    591  0.0  0.0  36632  2804 pts/0    R+   10:09   0:00 ps aux
```

To fix this problem we can use greate tool [dumb-init](https://github.com/Yelp/dumb-init).
```
headless@055f59e3c6a6:/$ ps aux 
USER        PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
headless      1  0.0  0.0   4048   668 ?        Ss   10:45   0:00 /usr/bin/dumb-init -- java -jar /opt/selenium/selenium-server-standalone.jar
headless      9  3.6  1.6 5630108 134180 ?      Ssl  10:45   0:05 java -jar /opt/selenium/selenium-server-standalone.jar
headless    198  0.0  0.0  18208  3376 pts/0    Ss   10:47   0:00 bash
headless    573  0.0  0.0  36632  2800 pts/0    R+   10:48   0:00 ps aux

$ run tests

headless@055f59e3c6a6:/$ ps aux
USER        PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
headless      1  0.0  0.0   4048   668 ?        Ss   10:45   0:00 /usr/bin/dumb-init -- java -jar /opt/selenium/selenium-server-standalone.jar
headless      9  3.9  1.9 5630108 159132 ?      Ssl  10:45   0:07 java -jar /opt/selenium/selenium-server-standalone.jar
headless    653  0.3  0.0  18208  3284 pts/0    Ss   10:48   0:00 bash
headless    907  0.0  0.0  36632  2856 pts/0    R+   10:48   0:00 ps aux
```